### PR TITLE
Change extension name v86

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Universal Video Maximizer
+# Video Maximizer (was Universal Video Maximizer)
 Chrome extension that finds and enlarges the main video filling browser window.
 
 
@@ -11,9 +11,11 @@ Just added the `./node_modules/@types/chrome` directory. After running `yarn ins
 
 
 # License
-Because AI bots are crawling code and putting it behind paywalls, this code is now
-Create Commons Attributed. You can use the code in your own projects to make them better, 
-sell your product, but you cannot turn around and sell my code.
+Because AI bots are crawling code and putting results behind paywalls, this code is now
+Create Commons Attributed. You can use the code in your own projects to make them better but you cannot turn around and sell my open source code.
+
+Please use it to create more awesome, free extensions, but do not just not
+clone this extension and and charge for it.
 
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 

--- a/src/first_use.html
+++ b/src/first_use.html
@@ -1,7 +1,7 @@
 <!Doctype html>
 <html lang="en">
 <head>
-  <title>Universal Video Maximizer</title>
+  <title>Video Maximizer</title>
   <meta charset="utf-8">
   <link href="chota.css" rel="stylesheet" type="text/css">
   <link href="first_use.css" rel="stylesheet" type="text/css">
@@ -22,7 +22,7 @@
 </div>
 <div class="is-hidden" id="tutorial">
   <b>Here's what it looks like</b> <br/>
-  <iframe id="tryitframe"></iframe>
+  <iframe title="Working example of extension popup controls" id="tryitframe"></iframe>
   <br class="half-br">This will show up <b>after</b> a video is maximized and you click the button again.
   <br/>
   <br/>Try it right now:

--- a/src/help.html
+++ b/src/help.html
@@ -1,17 +1,17 @@
 <!Doctype html>
 <html lang="en">
 <head>
-  <title>Universal Video Maximizer - Help</title>
+  <title>Video Maximizer - Help</title>
   <meta charset="utf-8">
   <link href="chota.css" rel="stylesheet" type="text/css">
 </head>
 <body class="dark">
 
 <div class="container">
-  <h1><img alt="logo" class="logo" src="icons/icon128.png">Universal Video Maximizer - version 3.0.82 Help</h1>
+  <h1><img alt="logo" class="logo" src="icons/icon128.png">Video Maximizer - version 3.0.82 Help</h1>
   <hr>
   <h2>
-    Beta version 3.0.85 (Aug 2023 update)
+    Beta version 3.0.86 (Aug 2023 update)
   </h2>
 
   <section class="padding-1">
@@ -240,7 +240,7 @@
     <p>If you have issues with local files working, you may want to check the extension permissions.</p>
     <ol>
       <li>Go into Chrome Extensions page <code>chrome://extensions/</code></li>
-      <li>Find the Universal VideoMaximizer in the list of extensions.</li>
+      <li>Find the VideoMaximizer in the list of extensions.</li>
       <li>Click the Details button</li>
       <li>Scroll down until you see the "Allow access to file URLs" and make sure it's enabled.</li>
     </ol>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Universal Video Maximizer BETA v3",
-  "version": "3.0.85",
+  "name": "Video Maximizer BETA v3",
+  "version": "3.0.86",
   "manifest_version": 3,
   "description": "Zoom videos and theater mode on most websites while maintaining your privacy.",
   "homepage_url": "https://github.com/trophygeek/universalvideomaximizer",
@@ -11,7 +11,7 @@
   },
   "default_locale": "en",
   "action": {
-    "default_title": "Click to zoom video on page.\nRight-click to see Options"
+    "default_title": "Click to zoom video on page.\nRight-click to change Options"
   },
   "background": {
     "service_worker": "background.js",

--- a/src/options.html
+++ b/src/options.html
@@ -1,7 +1,7 @@
 <!Doctype html>
 <html lang="en">
 <head>
-  <title>Universal Video Maximizer - Options</title>
+  <title>Video Maximizer - Options</title>
   <meta charset="utf-8">
   <link href="chota.css" rel="stylesheet" type="text/css">
   <link href="options.css" rel="stylesheet" type="text/css">
@@ -10,7 +10,7 @@
 <body class="dark">
 
 <div class="container">
-  <h1>Universal Video Maximizer - Options</h1>
+  <h1>Video Maximizer - Options</h1>
 
   <div class="container" id="mainForm">
     <fieldset>

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,7 +1,7 @@
 <!Doctype html>
 <html lang="en">
 <head>
-  <title>Universal Video Maximizer</title>
+  <title>Video Maximizer</title>
   <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="popup.css">
   <script type="module" src="popup.js"></script>


### PR DESCRIPTION
- Remove "universal" from name.
- Lower URL_OVERLAP_WEIGHT from 500 -> 100
- Double `-common` match weight for if there's a slider under a div.
- Use video url if it's under a nested <source> element.
- Reapply playback speed that can get lost if the video buffers. Ties into "canplay" event. ONLY for matched video so ads may need same treatment?
- v86