### PR TITLE
v110 - Message that BETA features are in stable channel

### DIFF
--- a/scripts/buildpackage.js
+++ b/scripts/buildpackage.js
@@ -11,14 +11,14 @@ const exec = commands => {
     shell: true,
   });
 };
-const spawnProcess = commands => {
-  spawn(commands, {
-    stdio: "inherit",
-    shell: true,
-  });
-};
+// const spawnProcess = commands => {
+//   spawn(commands, {
+//     stdio: "inherit",
+//     shell: true,
+//   });
+// };
 const readline = require("readline");
-const { is } = require("uvu/assert");
+// const { is } = require("uvu/assert");
 
 const rl = readline.createInterface({
                                       input:  process.stdin,
@@ -115,6 +115,8 @@ const doEdits = (filePath, from, to) => {
   if (oldContent.localeCompare(newContent) !== 0) {
     fs.writeFileSync(fullFilePath, newContent, { encoding: "utf-8" });
     console.log(`Edited file: ${fullFilePath}`);
+  } else {
+    console.warn(`Edited file: ${fullFilePath} did NOT change '${to}'?!?`);
   }
 };
 
@@ -129,7 +131,7 @@ rl.question("What version? ", (vers) => {
   }
   // todo: verify type is number.
 
-  rl.question("Beta (Y)? ", (isbetaStr) => {
+  rl.question("Beta (y)? ", (isbetaStr) => {
     isBeta = (isbetaStr?.toLowerCase() === "y");
     rl.close();
 
@@ -159,8 +161,6 @@ rl.question("What version? ", (vers) => {
       force:     true,
     });
 
-    debugger;
-
 // copy over all files.
     const buildSrcDir = path.resolve(__dirname, `../src`);
     fs.cpSync(buildSrcDir, buildTargetDir, { recursive: true });
@@ -172,13 +172,18 @@ rl.question("What version? ", (vers) => {
       doEdits(`../build/videomaximizer/manifest.json`,
               /"name": "Video Maximizer"/gi,
               `"name": "Video Maximizer BETA"`);
+      doEdits(`../build/videomaximizer/common.js`,
+              "export const IS_BETA_CHANNEL = false;",
+              "export const IS_BETA_CHANNEL = true;");
     }
-
-// now search/replace for VERSION_STR and BUILD_TYPE_STR in destination
-// zip it up.
     const buildDir = path.resolve(__dirname, `../build`);
-    exec(
-      `zip -r "${buildDir}/videomax-ext-v${vers}.zip" "${buildTargetDir}/" -x '**/.*' -x '**/__MACOSX'`);
+    const betaStr = isBeta ? "-BETA" : "";
+    // zip it up. use relative paths to prevent the zip file from containing full paths from the root.
+    // params r=recursive q=quiet 0=compression level
+    exec(`cd "${buildDir}" && zip -rq9 "./videomax-ext-v${vers}${betaStr}.zip" "./videomaximizer/" -x '**/.*' -x '**/__MACOSX'`);
+    console.log(`Compressed file: videomax-ext-v${vers}${betaStr}.zip
+    use 'unzip -vl ./build/videomax-ext-v${vers}${betaStr}.zip' to examine/verify contents. 
+    `);
   });
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -12,6 +12,7 @@
 
  */
 import {
+  IS_BETA_CHANNEL,
   UPDATE_NOTIFICATION_VERISON,
   CSS_FILE,
   CSS_STYLE_HEADER_ID,
@@ -997,6 +998,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
         case "UNZOOM_CMD":
           await unZoom(tabId, domain);
+        if (IS_BETA_CHANNEL) {
+          const settings = await getSettings();
+          if (!settings.beta3EndingShown) {
+              await chrome.tabs.create({
+                                         url:    chrome?.runtime?.getURL("beta_ending.html"),
+                                         active: false,
+                                       });
+            settings.beta3EndingShown = true;
+            await saveSettings(settings);
+            }
+            
+          }
+
           break;
 
         case "SET_SPEED_CMD":

--- a/src/beta_ending.html
+++ b/src/beta_ending.html
@@ -1,0 +1,56 @@
+<!Doctype html>
+<html lang="en">
+<head>
+  <title>Video Maximizer-BETA Ending</title>
+  <meta charset="utf-8">
+  <link href="chota.css" rel="stylesheet" type="text/css">
+</head>
+<body class="dark">
+
+<section>
+  <h1><img alt="logo" class="logo" src="icons/icon128.png">&nbsp;Video Maximizer - <span class="emphasis">Beta Ending</span></h1>
+  <hr>
+  <h2>
+    Oct 2023 Update: Thank-you! Thank-you! Thank-you!
+  </h2>
+  <section>
+    <p>
+      The Beta is COMPLETED and v3 with the Advanced Playback features has been rolled out. It is available Chrome
+      store's
+      official listing for "Video Maxmizer".
+    </p>
+
+    <p>
+      Now is a good time to <span class="emphasis">switch to the stable, official extention</span> since the BETA
+      channel
+      will start including less stable experimentsthat may break things periodically.
+    </p>
+    <p>
+      Install the stable version from the Chrome Store here:
+    </p>
+    <p class="margin-15">
+      <a class="button"
+         href="https://chrome.google.com/webstore/detail/video-maximizer/cdnlfphfngnfhjcnoikfhaomaaflaiie?hl=en"
+         rel="noopener" target="_blank">
+        <img alt="logo icon" src="./icons/icon128.png">
+        <span class="nav-center line-height-15">
+        Video Maximizer<br/>in the Chrome Store ↗
+        </span>
+      </a>
+    </p>
+    <p>&nbsp;</p>
+  </section>
+  <h2>Future Development</h2>
+  <section>
+    <p>
+      You can <span class="emphasis">follow development progress</span> (or report bugs/features), but visiting the
+      Github
+      open source
+      repo and starring it here:<br/>
+      <a href="https://github.com/trophygeek/universalvideomaximizer/" rel="noopener" target="_blank">
+        https://github.com/trophygeek/universalvideomaximizer/ ↗</a>
+    </p>
+  </section>
+</section>
+</body>
+</html>

--- a/src/chota.css
+++ b/src/chota.css
@@ -1456,3 +1456,10 @@ li button.del-btn-sel {
   font-style: italic;
 }
 
+.line-height-15 {
+  line-height: 1.5;
+}
+
+.margin-15 {
+  margin: 1.5em;
+}

--- a/src/common.js
+++ b/src/common.js
@@ -5,6 +5,8 @@ const DEBUG_ENABLED = FULL_DEBUG;
 const TRACE_ENABLED = FULL_DEBUG;
 const ERR_BREAK_ENABLED = FULL_DEBUG;
 
+export const IS_BETA_CHANNEL = false;
+
 export const DEFAULT_SPEED = "1.0";
 
 export const CSS_FILE = "videomax_inject.css";
@@ -39,7 +41,7 @@ export const SETTINGS_STORAGE_KEY = "settingsJson";
 
 // bumping this will cause the notification to show again. keep it pinned unless some major feature
 export const UPDATE_NOTIFICATION_VERISON = "85"; // will get out of sync. bump to show
-                                                      // notification
+// notification
 
 
 /* these are sites that are already zoomed, but playback speed is kind of nice */
@@ -64,6 +66,7 @@ export const DEFAULT_SETTINGS = {
   firstUseShown:             false, // set to true once first_use picks a mode.
   firstUseOn2ndScreen:       false,
   zoomExclusionListStr:      DEFAULT_ZOOM_EXCLUSION_LIST,
+  beta3EndingShown:          false,
 };
 
 /**

--- a/src/help.html
+++ b/src/help.html
@@ -11,7 +11,7 @@
   <h1><img alt="logo" class="logo" src="icons/icon128.png">Video Maximizer - Help</h1>
   <hr>
   <h2>
-    Sept 2023 Update (Version 3.0.109)
+    Oct 2023 Update (Version 3.0.110)
   </h2>
 
   <section class="padding-1">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Video Maximizer",
-  "version": "3.0.109",
+  "version": "3.0.110",
   "manifest_version": 3,
   "description": "Remove visual clutter and maximizes videos for easy viewing, including full-page theater mode on most sites.",
   "homepage_url": "https://github.com/trophygeek/universalvideomaximizer",

--- a/src/videomax_main_inject.js
+++ b/src/videomax_main_inject.js
@@ -2353,8 +2353,8 @@ try { // scope and prevent errors from leaking out to page.
      */
     const diceCoefficient = (str1, str2) => {
       let intersection = 0;
-      for (let ch1 of str1) {
-        for (let ch2 of str2) {
+      for (const ch1 of str1) {
+        for (const ch2 of str2) {
           if (ch1 === ch2) {
             intersection++;
           }


### PR DESCRIPTION
- fixes #43 
- This is a temporary message for beta users. `IS_BETA_CHANNEL` in common must be set to true to show.
- Update build to set flag for beta channel
- Fix zip to NOT include full path when unzipping (e.g. /volume/username/src/)