### PR TITLE
v113 - fix toggle mode

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -745,7 +745,7 @@ const getSettingUseAdvFeatures = async () => {
   try {
     const settings = await getSettings();
     trace("getFeatureShowZoomPopup settings:", JSON.stringify(settings, null, 2));
-    return (settings.useAdvancedFeatures || DEFAULT_SETTINGS.useAdvancedFeatures);
+    return (settings.useAdvancedFeatures);
   } catch (err) {
     logerr(err);
     return DEFAULT_SETTINGS.useAdvancedFeatures;

--- a/src/help.html
+++ b/src/help.html
@@ -11,7 +11,7 @@
   <h1><img alt="logo" class="logo" src="icons/icon128.png">Video Maximizer - Help</h1>
   <hr>
   <h2>
-    Oct 2023 Update (Version 3.0.112)
+    Oct 2023 Update (Version 3.0.114)
   </h2>
 
   <section class="padding-1">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Video Maximizer",
-  "version": "3.0.112",
+  "version": "3.0.113",
   "manifest_version": 3,
   "description": "Remove visual clutter and maximizes videos for easy viewing, including full-page theater mode on most sites.",
   "homepage_url": "https://github.com/trophygeek/universalvideomaximizer",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Video Maximizer",
-  "version": "3.0.113",
+  "version": "3.0.114",
   "manifest_version": 3,
   "description": "Remove visual clutter and maximizes videos for easy viewing, including full-page theater mode on most sites.",
   "homepage_url": "https://github.com/trophygeek/universalvideomaximizer",
@@ -33,7 +33,7 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'",
+    "extension_pages": "script-src 'self'; object-src 'self';",
     "sandbox": "sandbox allow-scripts; script-src 'self'; child-src 'self';"
   }
 }


### PR DESCRIPTION
Broke simple toggle mode in v112 when I removed the tutorial feature.

Problem was flipping the `useAdvancedFeatures ` default to `true`.

Hopefully, the chrome store will be quick about making it go live.