### PR TITLE
v115 CSP object-src 'self' -> object-src 'none'

### DIFF
--- a/src/help.html
+++ b/src/help.html
@@ -11,7 +11,7 @@
   <h1><img alt="logo" class="logo" src="icons/icon128.png">Video Maximizer - Help</h1>
   <hr>
   <h2>
-    Oct 2023 Update (Version 3.0.114)
+    Oct 2023 Update (Version 3.0.115)
   </h2>
 
   <section class="padding-1">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Video Maximizer",
-  "version": "3.0.114",
+  "version": "3.0.115",
   "manifest_version": 3,
   "description": "Remove visual clutter and maximizes videos for easy viewing, including full-page theater mode on most sites.",
   "homepage_url": "https://github.com/trophygeek/universalvideomaximizer",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -33,7 +33,7 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self';",
+    "extension_pages": "script-src 'self'; object-src 'none';",
     "sandbox": "sandbox allow-scripts; script-src 'self'; child-src 'self';"
   }
 }


### PR DESCRIPTION
We don't use any `<object>` and `<embed>`, so setting `object-src` to none